### PR TITLE
fix: description formatting in examples and frontmatter reference

### DIFF
--- a/skill-creator/references/examples.md
+++ b/skill-creator/references/examples.md
@@ -13,11 +13,7 @@ A basic knowledge skill. Single SKILL.md, no supporting files.
 ```yaml
 ---
 name: react-conventions
-description: >
-  React component conventions and patterns for this project. Use when
-  creating new React components, refactoring existing ones, or when
-  asking about component architecture, hooks patterns, or state
-  management in this codebase.
+description: React component conventions and patterns for this project. Use when creating new React components, refactoring existing ones, or when asking about component architecture, hooks patterns, or state management in this codebase.
 ---
 
 # React Conventions

--- a/skill-creator/references/frontmatter-reference.md
+++ b/skill-creator/references/frontmatter-reference.md
@@ -21,9 +21,7 @@ Complete documentation for SKILL.md frontmatter fields.
 Use the **WHAT + WHEN** pattern:
 
 ```yaml
-description: >
-  [WHAT it does]. Use when [WHEN to trigger], [more trigger
-  contexts], even if [near-miss scenario].
+description: [WHAT it does]. Use when [WHEN to trigger], [more trigger contexts], even if [near-miss scenario].
 ```
 
 See the main SKILL.md for detailed good/bad examples.


### PR DESCRIPTION
This pull request makes minor formatting changes to improve the readability and consistency of YAML frontmatter in documentation files. The changes primarily remove multi-line YAML strings in favor of single-line descriptions.

- Documentation formatting updates:
  * Updated the `description` field in the YAML frontmatter of `skill-creator/references/examples.md` to a single line for improved readability.
  * Changed the example `description` field in `skill-creator/references/frontmatter-reference.md` to use a single line instead of a multi-line block.