### PR TITLE
feat: add import-prototype skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ Skills are folders containing a `SKILL.md` file that teach the AI new capabiliti
 | [fusion-to-publish](./fusion-to-publish/)       | Register Fusion-built React components for use in Builder.io Publish's visual editor           |
 | [fusion-to-publish-v2](./fusion-to-publish-v2/) | Same as above + helper scripts for project detection, component scanning, and registration log |
 | [rules-reviewer](./rules-reviewer/)               | Review, fix, and create Builder.io Fusion rules files (`.builderrules`, `.mdc`, `agents.md`)   |
+| [import-prototype](./import-prototype/)           | Import a Builder.io prototype into the current project using the Builder dev-tools CLI          |
 
 ## Installation
 You can install skills by asking Builder to `run npx builder-doctor` which will give you an option to install a skill. You can also quickly add a specific skill by asking:
 - `npx builder-doctor install-skill skill-creator`
 - `npx builder-doctor install-skill fusion-to-publish`
 - `npx builder-doctor install-skill rules-reviewer`
+- `npx builder-doctor install-skill import-prototype`
 
 
 ## Skill Creator
@@ -47,6 +49,18 @@ npx builder-doctor install-skill rules-reviewer
 ### Reviewing rules
 
 Ask Builder to `Review my rules` after installing this skill. You can also ask `run npx builder-doctor rules` which will check for common issues with rule files.
+
+## Import Prototype
+Import a Builder.io prototype into the current project using the Builder dev-tools CLI.
+
+Ask Builder to run `npx builder-doctor install-skill import-prototype` and it will be installed in your project. Or you can run locally with:
+```bash
+npx builder-doctor install-skill import-prototype
+```
+
+### Using the skill
+
+Share a `https://builder.io/app/projects/...` URL with Builder and say what you want to import (e.g. "import the hero section" or "import the full page design"). The skill will run the Builder dev-tools CLI to pull the prototype into your project.
 
 ## Manual Installation
 

--- a/import-prototype/SKILL.md
+++ b/import-prototype/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: import-prototype
+description: Imports a Builder.io prototype into the current project by running the Builder dev-tools CLI. Use when the user mentions importing a prototype, a Builder.io URL, a builder.io/app/projects link, or wants to bring in designs or components from a Builder prototype. Triggers on phrases like "import prototype", "use this builder url", "import from builder", or when a builder.io/app/projects URL is shared.
+---
+
+# Import Prototype
+
+Import a Builder.io prototype into the current project using the Builder dev-tools CLI.
+
+## Instructions
+
+### Step 1: Get the Builder URL
+
+Ask the user for the Builder.io prototype URL if they haven't provided one. It must match this pattern:
+
+```
+https://builder.io/app/projects/...
+```
+
+Validate that the URL starts with `https://builder.io/app/projects/`. If the user provides a different URL format, tell them the URL must be of the form `https://builder.io/app/projects/...` and ask them to provide the correct one.
+
+### Step 2: Clarify the User's Intent
+
+If the user's intention for what to import from the prototype is unclear or unspecified, ask them:
+
+> "What would you like to import from this prototype? For example: the full layout, specific components, styles, or something else?"
+
+Use their answer as the `{prompt}` value. If the user's intent is already clear from context (e.g. "import the hero section" or "import the full page design"), use that directly without asking again.
+
+### Step 3: Run the CLI Command
+
+Run the following command using the Bash tool:
+
+```bash
+npx @builder.io/dev-tools@latest code --prototype "{builderUrl}" --prompt "{prompt}"
+```
+
+Replace `{builderUrl}` with the validated Builder.io URL and `{prompt}` with the user's stated intent.
+
+## Gotchas
+
+- **Always validate the URL format** before running the command. Reject URLs that don't start with `https://builder.io/app/projects/`.
+- **Don't assume intent.** If there's any ambiguity about what the user wants from the prototype, ask. A vague prompt produces poor output from the CLI.
+- **Quote both arguments** in the shell command to handle spaces and special characters correctly.
+- **The command uses npx**, so it always fetches the latest version of `@builder.io/dev-tools`. No installation step is needed.

--- a/rules-reviewer/SKILL.md
+++ b/rules-reviewer/SKILL.md
@@ -46,7 +46,8 @@ Search the project for:
 - `.builderrules` (root and nested directories)
 - `.builder/rules/*.mdc`
 - `agents.md`
-- Common mistakes: `.builderrule` (missing s), `AGENTS.md` (wrong case)
+- Common mistakes: `.builderrule` (missing s)
+- Note: `AGENTS.md` and `agents.md` are both valid — match case-insensitively
 
 ### Step 2: Analyze Each File
 

--- a/rules-reviewer/assets/examples.md
+++ b/rules-reviewer/assets/examples.md
@@ -365,7 +365,7 @@ Mobile-first approach:
 | Aspect | Guideline |
 |--------|-----------|
 | **File size** | < 150 lines preferred, never > 200 |
-| **Frontmatter** | Always include description + globs |
+| **Frontmatter** | Always include description + globs (`.mdc` files only; `agents.md` does not require frontmatter) |
 | **alwaysApply** | Use sparingly (max 3-5 files total) |
 | **Globs** | Specific patterns, not `**/*` |
 | **Content** | Specific, actionable, not vague |

--- a/rules-reviewer/assets/review-template.md
+++ b/rules-reviewer/assets/review-template.md
@@ -19,7 +19,7 @@ Use this template structure when presenting AI rules review results.
 
 ### [filename]
 - **Size**: X lines / Y chars [OK/WARNING/CRITICAL]
-- **Frontmatter**: [Present/Missing/Incomplete]
+- **Frontmatter**: [Present/Missing/Incomplete] *(`.mdc` files only — `agents.md` does not require frontmatter)*
 - **alwaysApply**: [true/false]
 - **Issues found**:
   - Issue 1

--- a/rules-reviewer/common-issues.md
+++ b/rules-reviewer/common-issues.md
@@ -66,14 +66,16 @@ globs:
 
 ---
 
-### 3. Missing Frontmatter
+### 3. Missing Frontmatter *(`.mdc` files only)*
+
+> **Note:** `agents.md` does not require frontmatter. This issue applies only to `.builder/rules/*.mdc` files.
 
 **Symptoms:**
 - Rules not being applied correctly
 - No scoping of rules
 - Missing context for AI
 
-**Detection:** Check if `.mdc` files start with `---` frontmatter block.
+**Detection:** Check if `.mdc` files start with `---` frontmatter block. Do not flag `agents.md` for missing frontmatter.
 
 **Impact:** Without frontmatter, the AI doesn't know when to apply rules or what they're for.
 
@@ -131,8 +133,9 @@ globs:
 | Wrong | Correct |
 |-------|---------|
 | `.builderrule` | `.builderrules` |
-| `AGENTS.md` | `agents.md` |
 | `.builder/rules/foo.md` | `.builder/rules/foo.mdc` |
+
+> **Note:** `AGENTS.md` and `agents.md` are both valid — agents file matching is case-insensitive.
 
 **Fix:** Rename files to match conventions exactly.
 


### PR DESCRIPTION
This pull request introduces a new "Import Prototype" skill for Builder.io, allowing users to import prototypes into their projects using the Builder dev-tools CLI. It also clarifies documentation and rules for handling frontmatter in rules files, especially distinguishing requirements for `.mdc` files versus `agents.md`. The most important changes are summarized below:

**New Skill Addition**

* Added the `import-prototype` skill, enabling users to import a Builder.io prototype into the current project via the Builder dev-tools CLI. Includes documentation and instructions for usage, trigger phrases, and validation steps. (`README.md`, `import-prototype/SKILL.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R64) [[3]](diffhunk://#diff-a965f399ba860fd5cf95ed90754b664a0eb41b9f31d2959ec4508044eb35f177R1-R45)

**Documentation Updates for Skills**

* Updated the `README.md` to include the new `import-prototype` skill in the list of available skills and installation instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R64)

**Rules Reviewer: Frontmatter Handling**

* Clarified that frontmatter is required only for `.mdc` files, not for `agents.md`, in the rules reviewer documentation, example templates, and common issues. [[1]](diffhunk://#diff-78f1a6d22041c70315b91da03110467e32f693873c74065c721f707beda01ea6L368-R368) [[2]](diffhunk://#diff-c71cdc517bd5b15da1c75d50e0087b4752b089d5f214cf3081e0ed51c3f2c1aeL22-R22) [[3]](diffhunk://#diff-df832d3b0616d74023421c828b1a04bbf663f9295ad7ce8f9aa397c95c877a23L69-R78)

**Rules Reviewer: File Matching and Case Sensitivity**

* Updated documentation to note that both `AGENTS.md` and `agents.md` are valid, and file matching for agents files is case-insensitive. [[1]](diffhunk://#diff-2c95d854a9382319f8e015af1f4ef91997fcf498c8de32358e38762f5bae4a88L49-R50) [[2]](diffhunk://#diff-df832d3b0616d74023421c828b1a04bbf663f9295ad7ce8f9aa397c95c877a23L134-R139)