### PR TITLE
feat: add create-instructions skill to generate AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Skills are folders containing a `SKILL.md` file that teach the AI new capabiliti
 | [ios-native](./ios-native/)                       | Build and run the iOS app on a simulator or physical device using `xcodebuild` and `native-run` |
 | [rules-reviewer](./rules-reviewer/)               | Review, fix, and create Builder.io Fusion rules files (`.builderrules`, `.mdc`, `agents.md`)   |
 | [import-prototype](./import-prototype/)           | Import a Builder.io prototype into the current project using the Builder dev-tools CLI          |
+| [create-instructions](./create-instructions/)     | Analyze the project's coding conventions and produce a concise `AGENTS.md`                     |
 
 ## Installation
 You can install skills by asking Builder to `run npx builder-doctor` which will give you an option to install a skill. You can also quickly add a specific skill by asking:
@@ -26,6 +27,7 @@ You can install skills by asking Builder to `run npx builder-doctor` which will 
 - `npx builder-doctor install-skill import-prototype`
 - `npx builder-doctor install-skill android-native`
 - `npx builder-doctor install-skill ios-native`
+- `npx builder-doctor install-skill create-instructions`
 
 
 ## Skill Creator
@@ -96,6 +98,18 @@ npx builder-doctor install-skill fusion-to-publish-v2
 ### Using the skill
 
 Ask Builder to run the V2 Fusion-to-Publish workflow. This version uses script helpers to detect project setup and scan components before registration.
+
+## Create Instructions
+Analyze the project's coding conventions and produce a concise `AGENTS.md` at the project root.
+
+Ask Builder to `run npx builder-doctor install-skill create-instructions` and it will be installed in your project. Or you can run locally with:
+```bash
+npx builder-doctor install-skill create-instructions
+```
+
+### Using the skill
+
+After installing, ask Builder "@create-instructions". The skill will explore your codebase, identify project-specific patterns, and write a concise `AGENTS.md` with up to 20 non-obvious, project-specific conventions. It will not overwrite an existing `AGENTS.md`.
 
 ## Android Native
 Build and run the Android app on an emulator or physical device using Gradle, `adb`, and `native-run`.
@@ -181,6 +195,8 @@ builder-agent-skills/
 ├── android-native/          # Build and run Android app
 │   └── SKILL.md
 ├── ios-native/              # Build and run iOS app
+│   └── SKILL.md
+├── create-instructions/     # Generate AGENTS.md from project conventions
 │   └── SKILL.md
 └── README.md
 ```

--- a/create-instructions/SKILL.md
+++ b/create-instructions/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: create-instructions
+disable-model-invocation: true
+description: Creates AGENTS.md with concise instructions if needed.
+---
+
+# create-instructions
+
+Analyze the project's coding conventions and produce a concise `AGENTS.md`.
+
+## Steps
+
+1. **Check for existing AGENTS.md** — if one already exists at the project root, stop and tell the user it already exists. Do not overwrite it.
+
+2. **Explore the codebase** — read a representative sample of source files (not config files) to identify patterns. Look at:
+   - How files and types are named
+   - How state management is handled
+   - Error handling patterns
+   - Testing conventions
+   - Any custom abstractions or wrappers used instead of primitives
+   - Patterns that deviate from the language/framework defaults
+   - If a folder convention is used what that convention is
+
+3. **Write AGENTS.md** — create it at the project root with these rules:
+   - At most 20 instructions
+   - Each instruction is a single line (no multi-line bullets)
+   - Only include things that are **unique to this project** and **non-obvious**
+   - Do NOT list the project's directory structure
+   - Do NOT include anything that is standard practice for the language or framework
+   - Do NOT include things a competent developer would infer automatically (e.g. "use Swift", "follow MVC")
+   - Focus on: project-specific patterns, naming conventions that deviate from defaults, custom abstractions the AI must use, gotchas specific to this codebase
+
+## Output Format
+
+```markdown
+# Project Coding Conventions
+
+- <single line instruction>
+- <single line instruction>
+...
+```
+
+## Gotchas
+
+- Don't pad the list to hit 20. Fewer sharp instructions beat 20 generic ones.
+- Avoid restating what the language/framework already enforces.
+- If you cannot find enough unique conventions to fill even 5 lines, say so and write what you found.


### PR DESCRIPTION
This pull request adds a new skill, `create-instructions`, to the project. The skill analyzes the project's coding conventions and generates a concise `AGENTS.md` file with up to 20 non-obvious, project-specific instructions. The documentation has been updated to reflect this addition, including installation and usage instructions.

**New Skill: `create-instructions`**

* Introduced the `create-instructions` skill, which analyzes the codebase for unique conventions and generates an `AGENTS.md` file at the project root. The skill avoids overwriting existing files and only documents non-obvious, project-specific patterns. (`create-instructions/SKILL.md`, [create-instructions/SKILL.mdR1-R47](diffhunk://#diff-fcb9e8c234f3dfd0d1c8f7641cc0210431488d0c18b452d585d48242f71367e4R1-R47))

**Documentation Updates**

* Added `create-instructions` to the skills table in `README.md` and updated installation instructions to include the new skill. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30)
* Provided a dedicated section in the `README.md` explaining the purpose, installation, and usage of the `create-instructions` skill.
* Updated the directory structure example in `README.md` to include the new `create-instructions/` folder.