### PR TITLE
feat: add mobile-testing skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Skills are folders containing a `SKILL.md` file that teach the AI new capabiliti
 | [ios-native](./ios-native/)                       | Build and run the iOS app on a simulator or physical device using `xcodebuild` and `native-run` |
 | [rules-reviewer](./rules-reviewer/)               | Review, fix, and create Builder.io Fusion rules files (`.builderrules`, `.mdc`, `agents.md`)   |
 | [import-prototype](./import-prototype/)           | Import a Builder.io prototype into the current project using the Builder dev-tools CLI          |
+| [create-instructions](./create-instructions/)     | Analyze the project's coding conventions and produce a concise `AGENTS.md`                     |
+| [mobile-testing](./mobile-testing/)               | Install Maestro, run end-to-end tests, and create new test flows for iOS and Android apps       |
 
 ## Installation
 You can install skills by asking Builder to `run npx builder-doctor` which will give you an option to install a skill. You can also quickly add a specific skill by asking:
@@ -26,6 +28,8 @@ You can install skills by asking Builder to `run npx builder-doctor` which will 
 - `npx builder-doctor install-skill import-prototype`
 - `npx builder-doctor install-skill android-native`
 - `npx builder-doctor install-skill ios-native`
+- `npx builder-doctor install-skill create-instructions`
+- `npx builder-doctor install-skill mobile-testing`
 
 
 ## Skill Creator
@@ -96,6 +100,35 @@ npx builder-doctor install-skill fusion-to-publish-v2
 ### Using the skill
 
 Ask Builder to run the V2 Fusion-to-Publish workflow. This version uses script helpers to detect project setup and scan components before registration.
+
+## Mobile Testing
+Run end-to-end UI tests on iOS and Android using Maestro. Covers installing Maestro, building apps, booting simulators/emulators, running existing flows, and authoring new ones.
+
+Ask Builder to `run npx builder-doctor install-skill mobile-testing` and it will be installed in your project. Or you can run locally with:
+```bash
+npx builder-doctor install-skill mobile-testing
+```
+
+### Using the skill
+
+Make sure [Maestro](https://maestro.dev/) is installed by running:
+```
+curl -Ls "https://get.maestro.mobile.dev" | bash
+```
+
+After installing, ask Builder to test your mobile app (e.g. "run the smoke test on iOS" or "write a Maestro flow for the login screen"). The skill handles Maestro installation, simulator/emulator setup, running flows from `maestro/`, and reporting pass/fail results with screenshot and log paths.
+
+## Create Instructions
+Analyze the project's coding conventions and produce a concise `AGENTS.md` at the project root.
+
+Ask Builder to `run npx builder-doctor install-skill create-instructions` and it will be installed in your project. Or you can run locally with:
+```bash
+npx builder-doctor install-skill create-instructions
+```
+
+### Using the skill
+
+After installing, ask Builder "@create-instructions". The skill will explore your codebase, identify project-specific patterns, and write a concise `AGENTS.md` with up to 20 non-obvious, project-specific conventions. It will not overwrite an existing `AGENTS.md`.
 
 ## Android Native
 Build and run the Android app on an emulator or physical device using Gradle, `adb`, and `native-run`.
@@ -181,6 +214,10 @@ builder-agent-skills/
 ├── android-native/          # Build and run Android app
 │   └── SKILL.md
 ├── ios-native/              # Build and run iOS app
+│   └── SKILL.md
+├── create-instructions/     # Generate AGENTS.md from project conventions
+│   └── SKILL.md
+├── mobile-testing/          # End-to-end UI testing with Maestro for iOS and Android
 │   └── SKILL.md
 └── README.md
 ```

--- a/mobile-testing/SKILL.md
+++ b/mobile-testing/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: mobile-testing
+description: >
+  Install Maestro, run end-to-end tests, and create new test flows for the
+  iOS and Android apps in this project. Use when the user asks to test the
+  mobile apps, verify a feature on iOS or Android, set up Maestro, run a
+  smoke test, write a new flow, or wants automated UI feedback after
+  implementing mobile functionality, even if they don't say "Maestro".
+---
+
+# Mobile Testing (Maestro for iOS + Android)
+
+Maestro drives the iOS Simulator and Android Emulator with simple YAML
+flows. Use it to verify functionality after changes to `ios-app/` or
+`android-app/`.
+
+## Quick Start
+
+1. Verify `builder.config.json` exists in the repo root with the required `allowedCommands` (see "Verify builder.config.json" below); create or update it if missing.
+2. Confirm Maestro is installed (`maestro --version`); if not, install it.
+3. Build and launch the relevant app on a simulator/emulator.
+4. Run an existing flow from `maestro/` or create one for the new feature.
+5. Report pass/fail plus screenshot/log paths back to the user.
+
+## Verify builder.config.json
+
+Before running any Maestro commands, ensure `builder.config.json` exists in the repository root and contains the following `allowedCommands` list. Without these entries the required shell commands (`maestro`, `xcrun`, `xcodebuild`, `./gradlew`, `adb`, etc.) will be blocked by ACL policy.
+
+```json
+{
+  "allowedCommands": [
+    "npm *",
+    "pnpm *",
+    "yarn *",
+    "yarn",
+    "bun *",
+    "bun",
+    "gh *",
+    "wc *",
+    "gradle *",
+    "gradle",
+    "rg *",
+    "./gradlew *",
+    "./gradlew",
+    "adb *",
+    "adb",
+    "vp *",
+    "vp",
+    "git *",
+    "export *",
+    "rails *",
+    "gem *",
+    "bundle *",
+    "rake *",
+    "echo *",
+    "cd *",
+    "find *",
+    "ls *",
+    "rm *",
+    "cp *",
+    "mv *",
+    "pwd",
+    "curl *",
+    "npx tsc *",
+    "head *",
+    "lsof *",
+    "kill *",
+    "ps *",
+    "tr *",
+    "awk *",
+    "cat *",
+    "grep *",
+    "sed *",
+    "tail *",
+    "touch *",
+    "mkdir *",
+    "tee *",
+    "true",
+    "uniq *",
+    "test *",
+    "false",
+    "npx *",
+    "sort *",
+    "env",
+    "dirname",
+    "basename *",
+    "realpath *",
+    "readlink *",
+    "stat *",
+    "file *",
+    "diff *",
+    "xargs *",
+    "chmod *",
+    "which *",
+    "whoami",
+    "uname *",
+    "uname",
+    "date",
+    "date *",
+    "printenv *",
+    "sleep *",
+    "netlify *",
+    "node *",
+    "tsx *",
+    "builderio *",
+    "builder *",
+    "open *",
+    "xcrun *",
+    "xcodebuild *",
+    "xcode-select *",
+    "xed *",
+    "agvtool *",
+    "maestro *",
+    "maestro"
+  ]
+}
+```
+
+If the file is missing, create it. If it exists but lacks any of the entries above, merge them in without removing existing allowed commands.
+
+## 1. Install Maestro
+
+Run only if `maestro --version` fails.
+
+```bash
+curl -Ls "https://get.maestro.mobile.dev" | bash
+export PATH="$PATH:$HOME/.maestro/bin"
+maestro --version
+```
+
+Platform prerequisites:
+- iOS: Xcode + at least one iOS Simulator runtime.
+- Android: Android SDK, an emulator AVD, `adb` on PATH.
+
+## 2. Build the Apps
+
+iOS (simulator build):
+```bash
+cd ios-app
+xcodebuild -project movie-rater.xcodeproj \
+  -scheme movie-rater \
+  -sdk iphonesimulator \
+  -configuration Debug \
+  -derivedDataPath build
+```
+Resulting `.app`: `ios-app/build/Build/Products/Debug-iphonesimulator/movie-rater.app`
+
+Android (debug APK):
+```bash
+cd android-app
+./gradlew :app:assembleDebug
+```
+Resulting `.apk`: `android-app/app/build/outputs/apk/debug/app-debug.apk`
+
+## 3. Boot a Simulator/Emulator and Install
+
+iOS:
+```bash
+xcrun simctl boot "iPhone 15" || true
+open -a Simulator
+xcrun simctl install booted <path-to>.app
+```
+
+Android:
+```bash
+emulator -list-avds
+emulator -avd <AvdName> &
+adb wait-for-device
+adb install -r <path-to>.apk
+```
+
+## 4. Run Tests
+
+```bash
+maestro test maestro/ios/smoke.yaml
+maestro test maestro/android/smoke.yaml
+maestro test maestro/                   # run all flows
+```
+
+Useful flags:
+- `--format junit --output report.xml` for CI.
+- `maestro studio` opens an interactive inspector (great for finding
+  selectors when authoring a new flow).
+- `maestro hierarchy` dumps the current screen's view tree.
+
+## 5. Create a New Test Flow
+
+Directory layout to follow:
+```
+maestro/
+  ios/        # iOS-specific entry flows
+  android/    # Android-specific entry flows
+  shared/     # reusable sub-flows
+```
+
+Minimum flow shape:
+```yaml
+appId: com.example.movierater   # iOS bundle id or Android package
+---
+- launchApp:
+    clearState: true
+- assertVisible: "Movies"
+- tapOn:
+    id: "movie-card-title"
+- assertVisible: "Details"
+```
+
+Authoring steps:
+1. Open `maestro studio` against a running app to discover selectors.
+2. Prefer `id:` selectors backed by stable accessibility identifiers.
+3. If identifiers are missing, add them in app code:
+   - SwiftUI: `.accessibilityIdentifier("movie-card-title")`
+   - Android Views: `android:contentDescription` or resource id
+   - Jetpack Compose: `Modifier.testTag("movie-card-title")` with
+     `semantics { testTagsAsResourceId = true }`
+4. Keep one user journey per flow file; extract shared steps to
+   `maestro/shared/` and `runFlow:` them.
+5. Re-run the flow until it passes deterministically.
+
+## 6. Reporting Back
+
+After running tests, surface to the user:
+- The flow file(s) executed.
+- Pass/fail summary and the failing step if any.
+- Paths to screenshots, recordings, and `~/.maestro/tests/<run>/` logs.
+- Any code changes made (e.g., added accessibility identifiers).
+
+## Gotchas
+
+- `appId` differs per platform — use the iOS bundle id in `maestro/ios/`
+  flows and the Android package name in `maestro/android/` flows.
+- The app must already be installed on the booted simulator/emulator
+  before `maestro test` runs; Maestro does not build apps.
+- Tests that rely on visible text break when copy changes; prefer
+  `id:` selectors with accessibility identifiers.
+- Compose `testTag` is invisible to Maestro unless
+  `testTagsAsResourceId = true` is set on the semantics root.
+- Only one iOS Simulator can be "booted" target at a time; if commands
+  hit the wrong device, shut others down with `xcrun simctl shutdown all`.
+- Android emulator boot is slow; always `adb wait-for-device` before
+  installing or testing.
+- Flaky network calls cause flaky tests — seed deterministic data or
+  mock the network in debug builds rather than retrying.
+- Don't introduce a custom back button in SwiftUI just to make a test
+  easier; it breaks the swipe-back gesture. Fix the selector instead.


### PR DESCRIPTION
This pull request adds two new skills—`mobile-testing` and `create-instructions`—to the Builder Agent Skills project, updating documentation and introducing a comprehensive skill guide for mobile app UI testing with Maestro. The main changes include updating the `README.md` to document the new skills, adding new directories for each skill, and providing detailed usage instructions for mobile testing.

**New Skills Added:**

* Added `mobile-testing` skill:
  - Enables end-to-end UI testing for iOS and Android apps using Maestro.
  - Includes a detailed `SKILL.md` with setup, usage, and troubleshooting instructions, command whitelisting requirements, and best practices for writing and running tests.

* Added `create-instructions` skill:
  - Analyzes the project's coding conventions and generates a concise `AGENTS.md` file with up to 20 project-specific conventions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R32) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R104-R132) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R218-R221)

**Documentation Updates:**

* Updated `README.md`:
  - Added both new skills to the skills table and installation instructions.
  - Provided detailed sections describing the purpose and usage of each skill, including prerequisites and example commands for installation and execution. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R32) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R104-R132) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R218-R221)

**Project Structure:**

* Created new directories:
  - `create-instructions/` and `mobile-testing/`, each containing a `SKILL.md` documenting the skill’s purpose and usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R218-R221) [[2]](diffhunk://#diff-1168c5035cdfc14bbc99d8c27b1598cf4f24be7b2141c23de7d5b41f405b4a17R1-R245)